### PR TITLE
Get rid of misleading 'get_lost' print in the beginning of process.

### DIFF
--- a/src/parser/ipt-model/sat-ipt-model.cpp
+++ b/src/parser/ipt-model/sat-ipt-model.cpp
@@ -58,8 +58,8 @@ public:
     ipt_output(INPUT& input) :
         got_to_eof_(), input_(input)
     {
-        context_.get_lost();
-
+        context_.lost_ = true;
+        context_.tnts_.clean();
         context_.resolve_relocation_callback =
             [this](rva& target) -> bool
             {


### PR DESCRIPTION
Initialize context properties without calling get_lost() method.

Signed-off-by: Jari Nippula <jari.nippula@intel.com>