### PR TITLE
Ignore zero tsc values in get_earliest_tsc()

### DIFF
--- a/src/parser/ipt-model/sat-ipt-task.cpp
+++ b/src/parser/ipt-model/sat-ipt-task.cpp
@@ -66,7 +66,8 @@ bool ipt_task::get_earliest_tsc(uint64_t& tsc) const
 
     if (imp_->blocks_.size()) {
         tsc    = imp_->blocks_.front()->tsc_.first;
-        got_it = true;
+        if (tsc != 0)
+            got_it = true;
     }
 
     return got_it;


### PR DESCRIPTION
The earliest tsc value got zeroed every time when a 0 zero was
read. Fix that by ignoring those values.

Signed-off-by: Anttu Koski <anttu.koski@intel.com>